### PR TITLE
Add configuration setting to control sending of messages if not /away.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ when you're not online.
   2. /set pushover_ignorefile - ignore messages from ....
   3. /set pushover_ignorechannels - space separated list of channels to ignore.
   4. /pushignore help - should get you started in populating the ignore list.
+  5. /set pushover_only_if_away [on|off] - if set to on, then you'll 
+        need to be set to away before we send notifications.

--- a/pushover.pl
+++ b/pushover.pl
@@ -171,17 +171,18 @@ sub check_ignore {
     }
     return 0;
 }
-sub check_ignore_channels {
-	my ($target) = @_;
-	my @ignore_channels = split(' ', Irssi::settings_get_str('pushover_ignorechannels'));
-	return 0 unless @ignore_channels;
-	if (grep {lc($_) eq lc($target)} @ignore_channels) {
-		debug("$target set as ignored channel.");
-		return 1;
-	}
 
-	return 0;
+sub check_ignore_channels {
+    my ($target) = @_;
+    my @ignore_channels = split(' ', Irssi::settings_get_str('pushover_ignorechannels'));
+    return 0 unless @ignore_channels;
+    if (grep {lc($_) eq lc($target)} @ignore_channels) {
+        debug("$target set as ignored channel.");
+        return 1;
+    }
+    return 0;
 }
+
 sub ignore_handler {
     my ($data, $server, $item) = @_;
     $data =~ s/\s+$//g;


### PR DESCRIPTION
The script currently only sends messages if the user has set themselves /away. 

Personally, I'm rather lazy, and never bother with /away .... so I've introduced a new setting (pushover_only_if_away) which controls whether we have to be away or not before sending notifications, and a new function (check_away()).

Request includes minor refactoring of code (hopefully making it easier to read). 

Other commit includes a re-indentation of the ignore_channel bit ... this seemed to be at 8 spaces or something. I'm too stupid to figure out how to split this into a separate pull request (Sorry).
